### PR TITLE
JP03: `Show Annotations` for all 3 images

### DIFF
--- a/parkington/notes.md
+++ b/parkington/notes.md
@@ -1,2 +1,0 @@
- - Contour Approximation is not working with booleans
- - OCR should be doing a better job of caching results for contours that have been identified previously. If the contours haven't changed, the OCR should not re-run in it.

--- a/parkington/params.yml
+++ b/parkington/params.yml
@@ -17,17 +17,13 @@
       increase_key : M
     - name         : contour_approximation
       display_name : Contour Approximation
-      value        : False
-      min          : False
-      max          : True
-      step         : 1
+      value        : false
+      is_boolean   : true
       increase_key : P
     - name         : enable_ocr
       display_name : Enable OCR
-      value        : False
-      min          : False
-      max          : True
-      step         : 1
+      value        : false
+      is_boolean   : true
       increase_key : O
     - name         : ocr_confidence_threshold
       display_name : OCR Confidence Threshold


### PR DESCRIPTION
- Adds a `ProcessingStep` for `show_annotations`
- Moves contour and OCR parameters under the new step
- Reworks the OCR dependencies to be toggleable for all image types