### PR TITLE
JP15: Consistent payloads for JSON objects

### DIFF
--- a/bookshelf_scanner/core/fuzzy_matcher/matcher.py
+++ b/bookshelf_scanner/core/fuzzy_matcher/matcher.py
@@ -90,19 +90,19 @@ class FuzzyMatcher:
         """
         return fuzz_utils.default_process(text)
 
-    def combine_texts(self, texts : list[tuple[str, float]]) -> list[str]:
+    def combine_texts(self, ocr_entries : list[dict[str, Any]]) -> list[str]:
         """
         Combines all texts into a single string, filtering by confidence threshold.
 
         Args:
-            texts: List of (text, confidence) tuples from OCR
+            ocr_entries: List of OCR result dictionaries with 'text' and 'confidence' keys
 
         Returns:
             List of text strings that passed the confidence threshold
         """
         filtered_texts = [
-            text for text, conf in texts
-            if conf >= self.min_ocr_confidence
+            entry["text"] for entry in ocr_entries
+            if entry["confidence"] >= self.min_ocr_confidence
         ]
         
         if filtered_texts:
@@ -173,10 +173,15 @@ class FuzzyMatcher:
 
         logger.info(f"Processing {total_images} images")
 
-        for image_num, (image_name, ocr_texts) in enumerate(ocr_results.items(), 1):
+        for image_num, (image_name, image_data) in enumerate(ocr_results.items(), 1):
             logger.info(f"\nProcessing image {image_num}/{total_images}: {image_name}")
-            
-            texts = self.combine_texts(ocr_texts)
+
+            # Expecting image_data to have an "ocr_results" key now
+            if "ocr_results" not in image_data:
+                logger.info("No 'ocr_results' key found")
+                continue
+
+            texts = self.combine_texts(image_data["ocr_results"])
             if not texts:
                 logger.info("No valid texts found")
                 continue

--- a/bookshelf_scanner/core/fuzzy_matcher/matcher.py
+++ b/bookshelf_scanner/core/fuzzy_matcher/matcher.py
@@ -32,7 +32,7 @@ class FuzzyMatcher:
     """
     PROJECT_ROOT      = Utils.find_root('pyproject.toml')
     REFERENCE_DB_PATH = PROJECT_ROOT / 'bookshelf_scanner' / 'data' / 'books.duckdb'
-    OCR_RESULTS_PATH  = PROJECT_ROOT / 'bookshelf_scanner' / 'data' / 'results' / 'extractor.json'
+    OCR_RESULTS_PATH  = PROJECT_ROOT / 'bookshelf_scanner' / 'data' / 'results' / 'optimizer.json'
     OUTPUT_FILE       = PROJECT_ROOT / 'bookshelf_scanner' / 'data' / 'results' / 'matcher.json'
 
     def __init__(

--- a/bookshelf_scanner/core/text_extractor/extractor.py
+++ b/bookshelf_scanner/core/text_extractor/extractor.py
@@ -353,9 +353,12 @@ class TextExtractor:
             image_name = image_path.name
             try:
                 ocr_results = self.perform_ocr(config_state = config_state, image_path = str(image_path))
-                results[image_name] = [
-                    (text, confidence) for _, text, confidence in ocr_results
-                ]
+                results[image_name] = {
+                    "ocr_results": [
+                        {"text": text, "confidence": confidence}
+                        for _, text, confidence in ocr_results
+                    ]
+                }
             except Exception as e:
                 logger.error(f"Failed to process image {image_name}: {e}")
                 continue

--- a/bookshelf_scanner/core/text_extractor/extractor.py
+++ b/bookshelf_scanner/core/text_extractor/extractor.py
@@ -301,12 +301,13 @@ class TextExtractor:
             output_json     : Whether to output OCR results to JSON file
             window_height   : Default window height for UI display (relevant for interactive mode)
         """
-        self.allowed_formats = allowed_formats or self.ALLOWED_FORMATS
-        self.config_file     = config_file or self.PARAMS_FILE
-        self.output_file     = output_file or self.OUTPUT_FILE
-        self.output_json     = output_json
-        self.window_height   = window_height
-        self.state           = None  # Will be set in interactive mode
+        self.allowed_formats   = allowed_formats or self.ALLOWED_FORMATS
+        self.collected_results = {}
+        self.config_file       = config_file or self.PARAMS_FILE
+        self.output_file       = output_file or self.OUTPUT_FILE
+        self.output_json       = output_json
+        self.window_height     = window_height
+        self.state             = None  # Will be set in interactive mode
 
         # Load base config and setup the Reader
         self.base_config  = OmegaConf.load(self.config_file)
@@ -364,9 +365,7 @@ class TextExtractor:
                 continue
 
         if self.output_json:
-            with self.output_file.open('w', encoding = 'utf-8') as f:
-                json.dump(results, f, ensure_ascii = False, indent = 4)
-            logger.info(f"OCR results saved to {self.output_file}")
+            self.save_to_json(results)
 
         return results
 
@@ -441,8 +440,7 @@ class TextExtractor:
             raise ValueError("No image files provided")
 
         # Set up the display state since we're in interactive mode
-        self.state = DisplayState(window_height = self.window_height)
-
+        self.state   = DisplayState(window_height = self.window_height)
         config_state = self.merge_steps_config(config_override = config_override)
 
         cv2.namedWindow(self.WINDOW_NAME, cv2.WINDOW_KEEPRATIO)
@@ -453,6 +451,14 @@ class TextExtractor:
                 current_image_path    = image_files[self.state.image_idx]
                 self.state.image_name = current_image_path.name
                 ocr_results           = self.perform_ocr(config_state = config_state, image_path = str(current_image_path))
+
+                # Collect results for potential JSON saving later
+                self.collected_results[self.state.image_name] = {
+                    "ocr_results": [
+                        {"text": text, "confidence": confidence}
+                        for _, text, confidence in ocr_results
+                    ]
+                }
 
                 if self.state.check_and_reset_new_image_flag():
                     self.log_ocr_results(ocr_results = ocr_results)
@@ -491,6 +497,9 @@ class TextExtractor:
 
         finally:
             cv2.destroyAllWindows()
+
+        if self.output_json and self.collected_results:
+            self.save_to_json(self.collected_results)
 
     # -------------------- OCR Operations --------------------
 
@@ -891,3 +900,17 @@ class TextExtractor:
             logger.info(f"OCR Results for image '{self.state.image_name}':")
             for _, text, confidence in ocr_results:
                 logger.info(f"Text: '{text}' with confidence {confidence:.2f}")
+
+    def save_to_json(self, results: dict):
+        """
+        Saves OCR results to a JSON file if output_json is True.
+
+        Args:
+            results : Dictionary of OCR results keyed by image name.
+        """
+        if not self.output_json:
+            return
+
+        with self.output_file.open('w', encoding = 'utf-8') as f:
+            json.dump(results, f, ensure_ascii = False, indent = 4)
+        logger.info(f"OCR results saved to {self.output_file}")

--- a/bookshelf_scanner/data/results/extractor.json
+++ b/bookshelf_scanner/data/results/extractor.json
@@ -1,401 +1,470 @@
 {
-    "0.jpg": [
-        [
-            "ANNE FRANK: THE DIARV OFAYOUING GIRL",
-            0.5741049251782034
+    "0.jpg": {
+        "ocr_results": [
+            {
+                "text": "ANNE FRANK: THE DIARV OFAYOUING GIRL",
+                "confidence": 0.5214801093153031
+            }
         ]
-    ],
-    "1.jpg": [
-        [
-            "6",
-            0.9146130154454255
-        ],
-        [
-            "THE TORESHADOWING",
-            0.47070782365778163
+    },
+    "1.jpg": {
+        "ocr_results": [
+            {
+                "text": "8",
+                "confidence": 0.5246203721395091
+            },
+            {
+                "text": "THE FORESHADOWING",
+                "confidence": 0.8816085501995992
+            }
         ]
-    ],
-    "10.jpg": [
-        [
-            "Chinese Cinderella",
-            0.8341664648033139
-        ],
-        [
-            "3",
-            0.8995842536938312
+    },
+    "10.jpg": {
+        "ocr_results": [
+            {
+                "text": "Chinese Cinderella",
+                "confidence": 0.7391946838568798
+            },
+            {
+                "text": "3",
+                "confidence": 0.6318886578665115
+            }
         ]
-    ],
-    "11.jpg": [
-        [
-            "ANN RINALDI",
-            0.6792358744323371
-        ],
-        [
-            "F",
-            0.8250909349066013
-        ],
-        [
-            "7",
-            0.9216431035313235
-        ],
-        [
-            "2",
-            0.8336602950115299
-        ],
-        [
-            "[",
-            0.7342646992217539
+    },
+    "11.jpg": {
+        "ocr_results": [
+            {
+                "text": "ANN RINALDI",
+                "confidence": 0.7488170300747217
+            },
+            {
+                "text": "F",
+                "confidence": 0.7762164222492096
+            },
+            {
+                "text": "7",
+                "confidence": 0.9454748413951997
+            },
+            {
+                "text": "Quilt",
+                "confidence": 0.9745857141023652
+            },
+            {
+                "text": "Harcourt",
+                "confidence": 0.7926985216546311
+            }
         ]
-    ],
-    "12.jpg": [
-        [
-            "Rabm",
-            0.4137307107448578
-        ],
-        [
-            "Betsy",
-            0.9986012437711698
-        ],
-        [
-            "Emperor",
-            0.9953900857956555
-        ],
-        [
-            "1",
-            0.34296012285341604
+    },
+    "12.jpg": {
+        "ocr_results": [
+            {
+                "text": "Betsy",
+                "confidence": 0.9998154317935324
+            },
+            {
+                "text": "0",
+                "confidence": 0.8858348095379966
+            },
+            {
+                "text": "Emperor",
+                "confidence": 0.9994566565196732
+            },
+            {
+                "text": "1",
+                "confidence": 0.3221627364906112
+            }
         ]
-    ],
-    "13.jpg": [
-        [
-            "Wolf by the Ears",
-            0.6834747310335029
-        ],
-        [
-            "Rinaldi",
-            0.9959950851564481
+    },
+    "13.jpg": {
+        "ocr_results": [
+            {
+                "text": "Wolf by the Ears",
+                "confidence": 0.6006328963721103
+            },
+            {
+                "text": "Rinaldi",
+                "confidence": 0.9989434001265077
+            }
         ]
-    ],
-    "14.jpg": [
-        [
-            "JOHNNY TREMAIN",
-            0.9946733274406421
-        ],
-        [
-            "1",
-            0.4765632016453516
-        ],
-        [
-            "1",
-            0.9595653865967648
+    },
+    "14.jpg": {
+        "ocr_results": [
+            {
+                "text": "JOHNNY TREMAIN",
+                "confidence": 0.7661316213255205
+            },
+            {
+                "text": "1",
+                "confidence": 0.516267457997003
+            },
+            {
+                "text": "1",
+                "confidence": 0.9674110774105884
+            }
         ]
-    ],
-    "15.jpg": [
-        [
-            "SOLDIER S HEART",
-            0.5611816693024415
-        ],
-        [
-            "0",
-            0.5961187617331554
-        ],
-        [
-            "GARY PAULSEN",
-            0.9752630112750789
+    },
+    "15.jpg": {
+        "ocr_results": [
+            {
+                "text": "SOLDIER S HEART",
+                "confidence": 0.6052743672294759
+            },
+            {
+                "text": "0",
+                "confidence": 0.4100943629439371
+            },
+            {
+                "text": "GARY PAULSEN",
+                "confidence": 0.993751704840613
+            }
         ]
-    ],
-    "16.jpg": [
-        [
-            "Confessiens %f Chartolte",
-            0.4626608417829021
-        ],
-        [
-            "7",
-            0.8997545387531005
-        ],
-        [
-            "Fv",
-            0.5005668612218452
-        ],
-        [
-            "4",
-            0.6720802807440265
+    },
+    "16.jpg": {
+        "ocr_results": [
+            {
+                "text": "IThe True Confessions %f ( hartolle",
+                "confidence": 0.18200801742549552
+            },
+            {
+                "text": "7",
+                "confidence": 0.6615267199695296
+            },
+            {
+                "text": "Fv",
+                "confidence": 0.491238293504924
+            }
         ]
-    ],
-    "17.jpg": [
-        [
-            "SuMMER",
-            0.9592519085727491
-        ],
-        [
-            "GERMAN SOLDIER",
-            0.8583360590474479
+    },
+    "17.jpg": {
+        "ocr_results": [
+            {
+                "text": "SuMMER",
+                "confidence": 0.9694781950469104
+            },
+            {
+                "text": "GERMAN SOLDIFR",
+                "confidence": 0.6979781226761379
+            },
+            {
+                "text": "1",
+                "confidence": 0.28188177304322437
+            }
         ]
-    ],
-    "18.jpg": [
-        [
-            "1",
-            0.6351080891549579
+    },
+    "18.jpg": {
+        "ocr_results": [
+            {
+                "text": "1",
+                "confidence": 0.5790932064329901
+            }
         ]
-    ],
-    "19.jpg": [
-        [
-            "SARAH BISHOP",
-            0.9640594736791886
-        ],
-        [
-            "SCOTT ODELL",
-            0.9072633450384723
-        ],
-        [
-            "42",
-            0.34573072989246334
+    },
+    "19.jpg": {
+        "ocr_results": [
+            {
+                "text": "SARAH BISHOP",
+                "confidence": 0.9833540640363193
+            },
+            {
+                "text": "SCOTT ODELL",
+                "confidence": 0.8731851044430242
+            },
+            {
+                "text": "42",
+                "confidence": 0.3646133719209549
+            }
         ]
-    ],
-    "2.jpg": [
-        [
-            "3",
-            0.8695119055560419
-        ],
-        [
-            "1",
-            0.6130955219308731
-        ],
-        [
-            "1",
-            0.6533895828330429
-        ],
-        [
-            "1",
-            0.9840057869327126
-        ],
-        [
-            "1",
-            0.8679183820709433
+    },
+    "2.jpg": {
+        "ocr_results": [
+            {
+                "text": "3",
+                "confidence": 0.8895395375070372
+            },
+            {
+                "text": "1",
+                "confidence": 0.5629426515378242
+            },
+            {
+                "text": "1",
+                "confidence": 0.6407227266571205
+            },
+            {
+                "text": "1",
+                "confidence": 0.9860817323311153
+            },
+            {
+                "text": "1",
+                "confidence": 0.8885178176117883
+            }
         ]
-    ],
-    "20.jpg": [
-        [
-            "Cvvys Civil War",
-            0.43155027104768234
-        ],
-        [
-            "BRENAMAN",
-            0.9990745728331324
-        ],
-        [
-            "1",
-            0.8243717665109784
+    },
+    "20.jpg": {
+        "ocr_results": [
+            {
+                "text": "Cvvys Civil War",
+                "confidence": 0.3733700604346228
+            },
+            {
+                "text": "BRENAMAN",
+                "confidence": 0.9993758930810668
+            },
+            {
+                "text": "1",
+                "confidence": 0.7137942903229408
+            }
         ]
-    ],
-    "21.jpg": [
-        [
-            "WARM BREAD",
-            0.918392698876273
-        ],
-        [
-            "1",
-            0.7510868461237443
-        ],
-        [
-            "Moskowitz SWFET",
-            0.5001209816654594
-        ],
-        [
-            "1",
-            0.8940681176848244
-        ],
-        [
-            "Lyon",
-            0.9106670022010803
+    },
+    "21.jpg": {
+        "ocr_results": [
+            {
+                "text": "1",
+                "confidence": 0.557863382486179
+            },
+            {
+                "text": "1",
+                "confidence": 0.723519758742114
+            },
+            {
+                "text": "1",
+                "confidence": 0.960469549579873
+            },
+            {
+                "text": "Lyon",
+                "confidence": 0.9503797888755798
+            },
+            {
+                "text": "Moskowitz SWFET",
+                "confidence": 0.6291032565501776
+            }
         ]
-    ],
-    "22.jpg": [
-        [
-            "1",
-            0.6773683651406515
-        ],
-        [
-            "RECONSTRUCTION AnD",
-            0.5025695760403207
-        ],
-        [
-            "2",
-            0.9313856629521666
+    },
+    "22.jpg": {
+        "ocr_results": [
+            {
+                "text": "31 DARK SKY RISING)",
+                "confidence": 0.696390873730689
+            },
+            {
+                "text": "!",
+                "confidence": 0.1884274427139454
+            },
+            {
+                "text": "3",
+                "confidence": 0.810355871656018
+            },
+            {
+                "text": "0",
+                "confidence": 0.8848467299565677
+            }
         ]
-    ],
-    "23.jpg": [
-        [
-            "8",
-            0.9527547407294925
-        ],
-        [
-            "2",
-            0.8803858869721495
-        ],
-        [
-            "8",
-            0.9988669983893352
-        ],
-        [
-            "ROBINSON",
-            0.9971393992617282
+    },
+    "23.jpg": {
+        "ocr_results": [
+            {
+                "text": "8",
+                "confidence": 0.9546539699647703
+            },
+            {
+                "text": "DREAM",
+                "confidence": 0.870810227769996
+            },
+            {
+                "text": "the",
+                "confidence": 0.994847576617892
+            },
+            {
+                "text": "ROBINSON",
+                "confidence": 0.9993362223132516
+            }
         ]
-    ],
-    "24.jpg": [
-        [
-            "HOME % the BRAVE",
-            0.6888965485233141
-        ],
-        [
-            "1",
-            0.8648754015287388
+    },
+    "24.jpg": {
+        "ocr_results": [
+            {
+                "text": "1",
+                "confidence": 0.5266168166510852
+            },
+            {
+                "text": "1",
+                "confidence": 0.8882892755246452
+            }
         ]
-    ],
-    "25.jpg": [
-        [
-            "With THE Might Of ANGELS",
-            0.7277740486997578
+    },
+    "25.jpg": {
+        "ocr_results": [
+            {
+                "text": "With THE Might Of ANGELS",
+                "confidence": 0.8483357095298609
+            }
         ]
-    ],
-    "26.jpg": [
-        [
-            "Fatewell 6 Manzanap",
-            0.4279811746131441
-        ],
-        [
-            "Houston",
-            0.6854248701126512
+    },
+    "26.jpg": {
+        "ocr_results": [
+            {
+                "text": "Fatewelt 6 Manzanar",
+                "confidence": 0.4682732889975573
+            },
+            {
+                "text": "Houston",
+                "confidence": 0.9760865667303981
+            }
         ]
-    ],
-    "27.jpg": [],
-    "28.jpg": [
-        [
-            "Lit CHAT",
-            0.8904399540531306
-        ],
-        [
-            "1",
-            0.3295037142611399
+    },
+    "27.jpg": {
+        "ocr_results": [
+            {
+                "text": "1",
+                "confidence": 0.7486402192466954
+            }
         ]
-    ],
-    "29.jpg": [
-        [
-            "IBOOK",
-            0.7173866788189086
-        ],
-        [
-            "8",
-            0.5927513700661144
-        ],
-        [
-            "3",
-            0.8146041092104248
+    },
+    "28.jpg": {
+        "ocr_results": [
+            {
+                "text": "Lit CHAT",
+                "confidence": 0.6645215648512727
+            },
+            {
+                "text": "1",
+                "confidence": 0.29803198112702844
+            },
+            {
+                "text": "L",
+                "confidence": 0.4180194259111545
+            }
         ]
-    ],
-    "3.jpg": [
-        [
-            "Hang",
-            0.859627902507782
-        ],
-        [
-            "Tho % S4n d",
-            0.4419656228073522
-        ],
-        [
-            "NNV",
-            0.9994015861370146
-        ],
-        [
-            "RINALDI",
-            0.7886948045506273
-        ],
-        [
-            "5",
-            0.9263474586993112
-        ],
-        [
-            "Trees with Ribbons",
-            0.8401046692420249
+    },
+    "29.jpg": {
+        "ocr_results": [
+            {
+                "text": "IBOOK",
+                "confidence": 0.5802047801275217
+            },
+            {
+                "text": "3",
+                "confidence": 0.9194152047720117
+            },
+            {
+                "text": "The game % borrowed phrases",
+                "confidence": 0.6176643640698949
+            }
         ]
-    ],
-    "4.jpg": [
-        [
-            "ANN RINALDI",
-            0.7694476921916305
+    },
+    "3.jpg": {
+        "ocr_results": [
+            {
+                "text": "Hang",
+                "confidence": 0.8697108626365662
+            },
+            {
+                "text": "puvs\"o4L",
+                "confidence": 0.33405391533136036
+            },
+            {
+                "text": "NNV",
+                "confidence": 0.9995473483127492
+            },
+            {
+                "text": "RINALDI",
+                "confidence": 0.7565222172223227
+            },
+            {
+                "text": "Trees with Ribbons",
+                "confidence": 0.8075837374885756
+            }
         ]
-    ],
-    "5.jpg": [
-        [
-            "ThE SECOND BEND IN THE RIVER",
-            0.5769982555426538
-        ],
-        [
-            "1",
-            0.6277180166725636
-        ],
-        [
-            "1",
-            0.9803923692794605
+    },
+    "4.jpg": {
+        "ocr_results": [
+            {
+                "text": "~Miue Eyes &Cave Seeu",
+                "confidence": 0.17615025908300774
+            },
+            {
+                "text": "ANN RINALDI",
+                "confidence": 0.6367143340527701
+            }
         ]
-    ],
-    "6.jpg": [
-        [
-            "William Lavenler",
-            0.7275485249358438
-        ],
-        [
-            "JUST",
-            0.9751982092857361
-        ],
-        [
-            "JANE",
-            0.9210155443287041
-        ],
-        [
-            "5",
-            0.6425594691174865
+    },
+    "5.jpg": {
+        "ocr_results": [
+            {
+                "text": "ThE SECOND BEND IN THE RIVER",
+                "confidence": 0.556321094359969
+            },
+            {
+                "text": "1",
+                "confidence": 0.7513571373721994
+            },
+            {
+                "text": "Ann Rinaldi",
+                "confidence": 0.9938236495722705
+            }
         ]
-    ],
-    "7.jpg": [
-        [
-            "BREA K",
-            0.9130062343748636
-        ],
-        [
-            "D",
-            0.9446115967405291
-        ],
-        [
-            "ANN",
-            0.9998287640819661
-        ],
-        [
-            "RINALD [",
-            0.694552918895968
-        ],
-        [
-            "with CHARity",
-            0.6937095072728555
-        ],
-        [
-            "5",
-            0.8700992620839685
+    },
+    "6.jpg": {
+        "ocr_results": [
+            {
+                "text": "William Lavenlcr",
+                "confidence": 0.42668510532319587
+            },
+            {
+                "text": "JUST",
+                "confidence": 0.9677479863166809
+            },
+            {
+                "text": "JANE",
+                "confidence": 0.9999858736991882
+            },
+            {
+                "text": "5",
+                "confidence": 0.9016300963494359
+            }
         ]
-    ],
-    "8.jpg": [
-        [
-            "FINISHING BECCA",
-            0.9836111586820092
-        ],
-        [
-            "1",
-            0.9095467710898362
+    },
+    "7.jpg": {
+        "ocr_results": [
+            {
+                "text": "BREA K",
+                "confidence": 0.92845340265978
+            },
+            {
+                "text": "D",
+                "confidence": 0.9377139456757142
+            },
+            {
+                "text": "ANN RINALD[",
+                "confidence": 0.7558813999437904
+            },
+            {
+                "text": "CHARity",
+                "confidence": 0.9726087965059617
+            },
+            {
+                "text": "1",
+                "confidence": 0.9253432234601497
+            }
         ]
-    ],
-    "9.jpg": [
-        [
-            "1",
-            0.5737956739912988
+    },
+    "8.jpg": {
+        "ocr_results": [
+            {
+                "text": "FINISHING BECCA",
+                "confidence": 0.9876166057551009
+            },
+            {
+                "text": "1",
+                "confidence": 0.906527057920048
+            }
         ]
-    ]
+    },
+    "9.jpg": {
+        "ocr_results": [
+            {
+                "text": "1",
+                "confidence": 0.5579419165184483
+            }
+        ]
+    }
 }

--- a/bookshelf_scanner/data/results/matcher.json
+++ b/bookshelf_scanner/data/results/matcher.json
@@ -1,7 +1,8 @@
 {
     "0.jpg": {
         "texts": [
-            "ANNE FRANK: THE DIARV OFAYOUING GIRL"
+            "THE DIARV OFAVOUNG GIRL",
+            "ANNE FRANK:"
         ],
         "matches": [
             {
@@ -17,7 +18,19 @@
             {
                 "title": "The Diary of a Young Girl",
                 "author": "Anne Frank",
-                "score": 0.9014084507042253
+                "score": 0.8857142857142857
+            }
+        ]
+    },
+    "1.jpg": {
+        "texts": [
+            "THE FORESHADOWING"
+        ],
+        "matches": [
+            {
+                "title": "The Foreshadowing",
+                "author": "Marcus Sedgwick",
+                "score": 1.0
             }
         ]
     },
@@ -36,6 +49,20 @@
                 "title": "Chinese Cinderella and the Secret Dragon Society",
                 "author": "Adeline Yen Mah",
                 "score": 0.9473684210526315
+            }
+        ]
+    },
+    "12.jpg": {
+        "texts": [
+            "Emperor",
+            "Betsy",
+            "Rabin"
+        ],
+        "matches": [
+            {
+                "title": "Betsy and the Emperor",
+                "author": "Staton Rabin,Larry Rostant",
+                "score": 1.0
             }
         ]
     },
@@ -78,7 +105,7 @@
     },
     "15.jpg": {
         "texts": [
-            "SOLDIER S HEART",
+            "SOLDIERS HEART",
             "0",
             "GARY PAULSEN"
         ],
@@ -86,12 +113,12 @@
             {
                 "title": "Soldier's Heart",
                 "author": "Gary Paulsen",
-                "score": 1.0
+                "score": 0.9473684210526315
             },
             {
                 "title": "Soldier's Heart",
                 "author": "Gary Paulsen",
-                "score": 1.0
+                "score": 0.9473684210526315
             },
             {
                 "title": "Liar, Liar",
@@ -102,35 +129,32 @@
     },
     "17.jpg": {
         "texts": [
+            "GERMAN SOLDIER",
             "SuMMER",
-            "GERMAN SOLDIER"
+            "1"
         ],
         "matches": [
             {
                 "title": "Summer of My German Soldier",
                 "author": "Bette Greene",
-                "score": 1.0
+                "score": 0.9545454545454546
             }
         ]
     },
     "18.jpg": {
         "texts": [
-            "1"
+            "DANIEL HALF HUMAN",
+            "CHOTJEWITZ"
         ],
         "matches": [
             {
-                "title": "Beautiful Volume 1",
-                "author": "Marie D'Abreo",
+                "title": "Daniel Half Human",
+                "author": "David Chotjewitz, Doris Orgel",
                 "score": 1.0
             },
             {
-                "title": "Fly to the Rescue (Tiny Geniuses #1)",
-                "author": "Megan E. Bryant",
-                "score": 1.0
-            },
-            {
-                "title": "Island Trilogy Volume 1-3",
-                "author": "Gordon Korman",
+                "title": "Daniel Half Human And The Good Nazi",
+                "author": "David Chotjewitz",
                 "score": 1.0
             }
         ]
@@ -138,142 +162,99 @@
     "19.jpg": {
         "texts": [
             "SARAH BISHOP",
-            "SCOTT ODELL",
-            "42"
+            "SCOTT ODELL"
         ],
         "matches": [
             {
                 "title": "Sarah Bishop",
                 "author": "Scott O'Dell",
-                "score": 0.8846153846153847
-            }
-        ]
-    },
-    "2.jpg": {
-        "texts": [
-            "3",
-            "1",
-            "1",
-            "1",
-            "1"
-        ],
-        "matches": [
-            {
-                "title": "Island Trilogy Volume 1-3",
-                "author": "Gordon Korman",
-                "score": 1.0
-            },
-            {
-                "title": "Dragon Ball (3-in-1 Edition) Vol. 1",
-                "author": "Akira Toriyama",
-                "score": 1.0
-            },
-            {
-                "title": "Cupcake Diaries 3 Books in 1! #3",
-                "author": "Coco Simon",
-                "score": 1.0
-            }
-        ]
-    },
-    "20.jpg": {
-        "texts": [
-            "Cvvys Civil War",
-            "BRENAMAN",
-            "1"
-        ],
-        "matches": [
-            {
-                "title": "Evvy's Civil War",
-                "author": "Miriam Brenaman",
-                "score": 0.8181818181818181
-            }
-        ]
-    },
-    "22.jpg": {
-        "texts": [
-            "1",
-            "RECONSTRUCTION AnD",
-            "2"
-        ],
-        "matches": [
-            {
-                "title": "Reconstruction and Reform",
-                "author": "Joy Hakim",
-                "score": 0.9
-            },
-            {
-                "title": "Reconstruction and Reform",
-                "author": "Joy Hakim",
-                "score": 0.9
-            },
-            {
-                "title": "Reconstruction and Reform",
-                "author": "Joy Hakim",
-                "score": 0.9
+                "score": 0.9387755102040817
             }
         ]
     },
     "23.jpg": {
         "texts": [
             "8",
-            "2",
-            "8",
+            "DREAM",
+            "the",
+            "Q0)",
             "ROBINSON"
         ],
         "matches": [
             {
-                "title": "The 3-2-3 Detective Agency in the Disappearance of Dave Warthog",
-                "author": "Fiona Robinson",
-                "score": 0.9090909090909091
-            },
-            {
-                "title": "The 3-2-3 Detective Agency in the Disappearance of Dave Warthog",
-                "author": "Fiona Robinson",
-                "score": 0.9090909090909091
-            },
-            {
-                "title": "The 3-2-3 Detective Agency in the Disappearance of Dave Warthog",
-                "author": "Fiona Robinson",
-                "score": 0.9090909090909091
+                "title": "Child of the Dream",
+                "author": "Sharon Robinson",
+                "score": 0.878048780487805
             }
         ]
     },
     "24.jpg": {
         "texts": [
             "HOME % the BRAVE",
-            "1"
+            "APPLEGATE"
         ],
         "matches": [
             {
                 "title": "Home of the Brave",
                 "author": "Katherine Applegate",
-                "score": 0.9333333333333332
+                "score": 1.0
             },
             {
-                "title": "Home of the Brave: An American History Book for Kids: 15 Immigrants Who Shaped U.S. History (Biographies for Kids)",
-                "author": "Brooke Khan",
-                "score": 0.9333333333333332
+                "title": "Brave the Betrayal",
+                "author": "Katherine Applegate",
+                "score": 0.8837209302325582
+            },
+            {
+                "title": "Brave the Betrayal",
+                "author": "Katherine Applegate",
+                "score": 0.8837209302325582
             }
         ]
     },
     "25.jpg": {
         "texts": [
-            "With THE Might Of ANGELS"
+            "3",
+            "ANGELS",
+            "WITH THE MIGHJ OF"
         ],
         "matches": [
             {
                 "title": "With the Might of Angels",
                 "author": "Andrea Davis Pinkney",
-                "score": 1.0
+                "score": 0.8181818181818181
+            }
+        ]
+    },
+    "26.jpg": {
+        "texts": [
+            "1",
+            "Manzanar",
+            "Houston"
+        ],
+        "matches": [
+            {
+                "title": "Farewell to Manzanar",
+                "author": "Jeanne Wakatsuki Houston, James D. Houston",
+                "score": 0.9411764705882354
+            },
+            {
+                "title": "Farewell to Manzanar",
+                "author": "Jeanne Wakatsuki Houston",
+                "score": 0.9411764705882354
+            },
+            {
+                "title": "Farewell to Manzanar",
+                "author": "Jeanne Houston",
+                "score": 0.9411764705882354
             }
         ]
     },
     "3.jpg": {
         "texts": [
             "Hang",
-            "Tho % S4n d",
-            "NNV",
-            "RINALDI",
+            "Thousand",
+            "ANN",
+            "RINAL DI",
             "5",
             "Trees with Ribbons"
         ],
@@ -281,69 +262,46 @@
             {
                 "title": "Hang a Thousand Trees with Ribbons",
                 "author": "Ann Rinaldi",
-                "score": 0.8387096774193549
-            }
-        ]
-    },
-    "4.jpg": {
-        "texts": [
-            "ANN RINALDI"
-        ],
-        "matches": [
-            {
-                "title": "Girl in Blue",
-                "author": "Ann Rinaldi",
-                "score": 1.0
-            },
-            {
-                "title": "Amelia's War",
-                "author": "Ann Rinaldi",
-                "score": 1.0
-            },
-            {
-                "title": "Numbering All the Bones",
-                "author": "Ann Rinaldi",
-                "score": 1.0
+                "score": 0.9247311827956989
             }
         ]
     },
     "5.jpg": {
         "texts": [
-            "ThE SECOND BEND IN THE RIVER",
-            "1",
-            "1"
+            "Ann Rinaldi",
+            "THE SECOND BEND IN THE RIVER",
+            "FON SONATURE"
         ],
         "matches": [
             {
                 "title": "Second Bend in the River",
                 "author": "Ann Rinaldi",
-                "score": 0.96
+                "score": 1.0
             }
         ]
     },
     "6.jpg": {
         "texts": [
-            "William Lavenler",
-            "JUST",
-            "JANE",
+            "William Lavender",
+            "JUST JANE",
             "5"
         ],
         "matches": [
             {
                 "title": "Just Jane",
                 "author": "William Lavender",
-                "score": 0.9259259259259259
+                "score": 1.0
             }
         ]
     },
     "7.jpg": {
         "texts": [
             "BREA K",
-            "D",
+            "V",
             "ANN",
             "RINALD [",
-            "with CHARity",
-            "5"
+            "8",
+            "with CHARity"
         ],
         "matches": [
             {
@@ -356,34 +314,25 @@
     "8.jpg": {
         "texts": [
             "FINISHING BECCA",
-            "1"
+            "1",
+            "CU!"
         ],
         "matches": [
             {
                 "title": "Finishing Becca",
                 "author": "Ann Rinaldi",
-                "score": 0.9375
+                "score": 0.8571428571428571
             }
         ]
     },
     "9.jpg": {
         "texts": [
-            "1"
+            "BEYOND THE BURNING"
         ],
         "matches": [
             {
-                "title": "Beautiful Volume 1",
-                "author": "Marie D'Abreo",
-                "score": 1.0
-            },
-            {
-                "title": "Fly to the Rescue (Tiny Geniuses #1)",
-                "author": "Megan E. Bryant",
-                "score": 1.0
-            },
-            {
-                "title": "Island Trilogy Volume 1-3",
-                "author": "Gordon Korman",
+                "title": "Beyond the Burning Time",
+                "author": "Kathryn Lasky",
                 "score": 1.0
             }
         ]


### PR DESCRIPTION
- Both `extractor` and `optimizer` now uses the same `ocr_results` dictionary of "texts" and "confidences"
- Now `matcher` expects the dictionary format, which is more performant for the use case
- `matcher` expects to source from the `optimizer` payload by default

@SeanMainer, I'm going to merge this branch in, so the `matcher.json` you see uses optimized results now, which is what we expect the final program to do.