### PR TITLE
Add matcherToCSV.py to convert matcher.JSON results to CSV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Log files
 *.log
+.DS_Store
 
 #All pycache files
 **/__pycache__/

--- a/bookshelf_scanner/data/results/matcherToCSV.py
+++ b/bookshelf_scanner/data/results/matcherToCSV.py
@@ -1,0 +1,40 @@
+import json
+import csv
+import os
+
+def convert_matcher_to_csv(json_file_path, output_csv_path):
+    try:
+        # Read the matcher.json file
+        with open(json_file_path, 'r') as json_file:
+            data = json.load(json_file)
+
+        # Open the CSV file for writing
+        with open(output_csv_path, mode='w', newline='', encoding='utf-8') as csv_file:
+            writer = csv.writer(csv_file)
+
+            # Write the headers
+            writer.writerow(["filename", "title", "author", "confidence score (%)"])
+
+            # Process each file's data
+            for filename, content in data.items():
+                matches = content.get("matches", [])
+                for match in matches:
+                    title = match.get("title", "N/A")
+                    author = match.get("author", "N/A")
+                    score = match.get("score", 0) * 100  # Convert to percentage
+
+                    # Write the row
+                    writer.writerow([filename, title, author, f"{score:.1f}%"])
+
+        print(f"CSV file successfully created at: {output_csv_path}")
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+# File paths (adjust as needed)
+current_dir = os.path.dirname(__file__)
+json_file_path = os.path.join(current_dir, "matcher.json")
+output_csv_path = os.path.join(current_dir, "matcher_results.csv")
+
+# Convert the JSON to CSV
+convert_matcher_to_csv(json_file_path, output_csv_path)

--- a/bookshelf_scanner/data/results/matcher_results.csv
+++ b/bookshelf_scanner/data/results/matcher_results.csv
@@ -1,0 +1,33 @@
+filename,title,author,confidence score (%)
+0.jpg,Anne Frank,Anne Frank,100.0%
+0.jpg,Anne Frank,Anne Frank,100.0%
+0.jpg,The Diary of a Young Girl,Anne Frank,88.6%
+1.jpg,The Foreshadowing,Marcus Sedgwick,100.0%
+10.jpg,Chinese Cinderella,Adeline Yen Mah,94.7%
+10.jpg,Chinese Cinderella and the Secret Dragon Society,Adeline Yen Mah,94.7%
+12.jpg,Betsy and the Emperor,"Staton Rabin,Larry Rostant",100.0%
+13.jpg,Wolf by the Ears,Ann Rinaldi,100.0%
+14.jpg,Johnny Tremain,Esther Hoskins Forbes,93.3%
+14.jpg,Johnny Tremain,Esther Forbes,93.3%
+14.jpg,Johnny Tremain,Esther Forbes,93.3%
+15.jpg,Soldier's Heart,Gary Paulsen,94.7%
+15.jpg,Soldier's Heart,Gary Paulsen,94.7%
+15.jpg,"Liar, Liar",Gary Paulsen,82.8%
+17.jpg,Summer of My German Soldier,Bette Greene,95.5%
+18.jpg,Daniel Half Human,"David Chotjewitz, Doris Orgel",100.0%
+18.jpg,Daniel Half Human And The Good Nazi,David Chotjewitz,100.0%
+19.jpg,Sarah Bishop,Scott O'Dell,93.9%
+23.jpg,Child of the Dream,Sharon Robinson,87.8%
+24.jpg,Home of the Brave,Katherine Applegate,100.0%
+24.jpg,Brave the Betrayal,Katherine Applegate,88.4%
+24.jpg,Brave the Betrayal,Katherine Applegate,88.4%
+25.jpg,With the Might of Angels,Andrea Davis Pinkney,81.8%
+26.jpg,Farewell to Manzanar,"Jeanne Wakatsuki Houston, James D. Houston",94.1%
+26.jpg,Farewell to Manzanar,Jeanne Wakatsuki Houston,94.1%
+26.jpg,Farewell to Manzanar,Jeanne Houston,94.1%
+3.jpg,Hang a Thousand Trees with Ribbons,Ann Rinaldi,92.5%
+5.jpg,Second Bend in the River,Ann Rinaldi,100.0%
+6.jpg,Just Jane,William Lavender,100.0%
+7.jpg,A Break with Charity,Ann Rinaldi,90.9%
+8.jpg,Finishing Becca,Ann Rinaldi,85.7%
+9.jpg,Beyond the Burning Time,Kathryn Lasky,100.0%


### PR DESCRIPTION
This includes implementation of fuzzy-matcher-to-csv.py script which simply extracts the "matches" from matcher.json and formats them into a csv file. 
The idea here is that this csv file would be an easily 'human' readable version of the matches found using this program.
Formats csv into four columns:
filename | title | author | confidence score
Considered setting confidence minimum threshhold here, but given most are >80%, did not do this yet.
**NOTE results currently pulling from matcher.json which is still using non-optimized outputs from book_segmenter. This also means not ALL images are showing as output.
Other issues:
--Multiple matches in matcher.json for each image means we have multiple csv row entries per image
